### PR TITLE
Allow setting a default file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ let g:silicon = {
       \ 'line-number':           v:true,
       \ 'round-corner':          v:true,
       \ 'window-controls':       v:true,
+      \ 'default-file-pattern'       '',
       \ }
 ```
 

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -85,7 +85,7 @@ let s:default_cmd = {
 
 let s:default_vim = { }
 
-let s:default = extend(s:default_vim, s:default_cmd)
+let s:default = extend(copy(s:default_cmd), s:default_vim)
 
 call s:configure('g:silicon', s:default)
 
@@ -146,11 +146,10 @@ endfun
 
 " Silicon bindings
 fun! s:cmd(argc, argv)
-  let cmd = ['silicon']
+  return ['silicon']
         \ + s:cmd_output(a:argc, a:argv)
         \ + s:cmd_language(a:argc, a:argv)
         \ + s:cmd_config(a:argc, a:argv)
-  return cmd
 endfun
 
 if has('nvim')

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -13,16 +13,16 @@ en
 " Plugin-independent Helpers
 
 " Mapping from type-number to type-name
-let s:typename = {
-      \ 0: 'number',
-      \ 1: 'string',
-      \ 2: 'func',
-      \ 3: 'list',
-      \ 4: 'dict',
-      \ 5: 'float',
-      \ 6: 'boolean',
-      \ 7: 'null',
-      \ }
+let s:typename = [
+      \ 'number',
+      \ 'string',
+      \ 'func',
+      \ 'list',
+      \ 'dict',
+      \ 'float',
+      \ 'boolean',
+      \ 'null',
+      \ ]
 
 " First, check that silicon is installed. Then, check for unexpected keys and
 " type mismatches in a:config, using a:default as reference. If any are found,

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -88,12 +88,31 @@ let s:default = {
 
 call s:configure('g:silicon', s:default)
 
+if !exists('g:silicon_default_file_pattern')
+  " Examples:
+  "   ~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png
+  "   ~/images/silicon-{time:%s}.png
+  "
+  let g:silicon_default_file_pattern = ''
+endif
+
 " Silicon bindings
 fun! s:cmd(argc, argv)
   let cmd = ['silicon']
   " Output method
   if a:argc == 0
-    if empty(executable('xclip'))
+    if len(g:silicon_default_file_pattern) > 0
+      let path = g:silicon_default_file_pattern
+      let path = substitute(g:silicon_default_file_pattern,
+            \ '{time:\(.\{-}\)}', {match -> strftime(match[1])}, 'g')
+      let path = fnamemodify(path, ':p')
+
+      if !empty(fnamemodify(path, ':e'))
+        let cmd += ['--output', path]
+      el
+        let cmd += ['--output', path.'.png']
+      en
+    elseif empty(executable('xclip'))
       throw 'Copying to clipboard is only supported on Linux with xclip installed. '
             \ .'Please specify a path instead.'
     el

--- a/doc/silicon.txt
+++ b/doc/silicon.txt
@@ -70,7 +70,8 @@ visual line selection highlighted.
 ==============================================================================
 OPTIONS                                                  *vim-silicon-options*
 
-    g:silicon .................................................... |g:silicon|
+    g:silicon ............................... |g:silicon|
+    g:silicon['default-file-name'] .......... |g:silicon['default-file-name']|
 
 ------------------------------------------------------------------------------
                                                                    *g:silicon*
@@ -91,6 +92,7 @@ Default: ~
           \ 'line-number':           v:true,
           \ 'round-corner':          v:true,
           \ 'window-controls':       v:true,
+          \ 'default-file-pattern'       '',
           \ }
 >
 
@@ -102,26 +104,27 @@ To get the list of available themes, you can run this in the terminal:
 
 For more details about options, please see https://github.com/Aloxaf/silicon.
 
-                                              *g:silicon_default_file_pattern*
-Type: string ~
-Default: ~
->
-    let g:silicon_default_file_pattern = ''
->
+------------------------------------------------------------------------------
+                                           *g:silicon['default-file-pattern']*
 
-If it's set to a non-empty string, it'll be used as the default filename when
+If set to a non-empty string, it'll be used as the default filename when
 |:Silicon| is called with no arguments. Note that this means you could no
 longer copy to clipboard, unless you manually reset it to an empty string.
 
 It's possible to embed a timestamp into the filename by using the
-`{time:<strftime specifier>}` format. As an example:
+`{time:<strftime() specifier>}` format. As an example:
 
 >
-    let g:silicon_default_file_pattern = '~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png'
+    let g:silicon['default-file-pattern'] =
+            \ '~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png'
 >
 
 This might result in the file: `~/images/silicon-2019-08-10-164233.png`.
 
+Similarly, `{file:<expand() specifier>}` can be used to embed filename
+information.
+
+See |strftime()| and |expand()| for more information.
 
 ==============================================================================
 NOTES                                                      *vim-silicon-notes*

--- a/doc/silicon.txt
+++ b/doc/silicon.txt
@@ -48,7 +48,8 @@ Generate a code image from a buffer or visual line selection.
 Examples:
 
 >
-    " Generate an image of the current buffer and write it to clipboard
+    " Generate an image of the current buffer and write it to the clipboard,
+    " or to a default file path
     :Silicon
 
     " Generate an image of the current buffer
@@ -100,6 +101,27 @@ To get the list of available themes, you can run this in the terminal:
 >
 
 For more details about options, please see https://github.com/Aloxaf/silicon.
+
+                                              *g:silicon_default_file_pattern*
+Type: string ~
+Default: ~
+>
+    let g:silicon_default_file_pattern = ''
+>
+
+If it's set to a non-empty string, it'll be used as the default filename when
+|:Silicon| is called with no arguments. Note that this means you could no
+longer copy to clipboard, unless you manually reset it to an empty string.
+
+It's possible to embed a timestamp into the filename by using the
+`{time:<strftime specifier>}` format. As an example:
+
+>
+    let g:silicon_default_file_pattern = '~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png'
+>
+
+This might result in the file: `~/images/silicon-2019-08-10-164233.png`.
+
 
 ==============================================================================
 NOTES                                                      *vim-silicon-notes*


### PR DESCRIPTION
Copying the image to the clipboard is interesting, but a bit inconvenient, since I still have to manually save it to a file with a name I need to chose. Ideally, I'd like this to work as a screenshotting tool that just creates timestamped files in known directories.

This PR implements this functionality, but I'm quite open to different ways to pull it off. For instance, the setting is separate from `g:silicon`, since that variable represents the command-line settings, so this new setting would sit quite odd with it. I'd be okay with doing this another way (I'd consider renaming `g:silicon` to `g:silicon_cmdline_settings` or something, myself). I'll leave a few more comments in the PR with thoughts.

If you'd rather keep the plugin minimal, I'm fine with closing the PR -- let me know.