### PR TITLE
Allow overriding parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ To get the list of available themes, you can run this in the terminal:
 silicon --list-themes
 ```
 
+Silicon internally uses [`bat`'s](https://github.com/sharkdp/bat) themes and syntaxes. To get the list of supported languages, you could:
+
+```sh
+cargo install bat
+bat --list-languages
+```
+
 For more details about options, see https://github.com/Aloxaf/silicon.
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Plug 'segeljakt/vim-silicon'
 
 # Commands
 
-The available commands are `Silicon`, and `SiliconHighlight`:
+This plugin provides a single command `Silicon`:
 
 ```vim
 " Generate an image of the current buffer and write it to /path/to/output.png
@@ -42,7 +42,7 @@ The available commands are `Silicon`, and `SiliconHighlight`:
 :'<,'>Silicon /path/to/output.png
 
 " Generate an image of the current buffer, with the current visual line selection highlighted.
-:'<,'>SiliconHighlight /path/to/output.png
+:'<,'>Silicon! /path/to/output.png
 ```
 
 If no `/path/to/output.png` is specified, then the generated image is copied to clipboard. However, this feature is only supported on Linux at the moment.
@@ -53,21 +53,27 @@ This is the default configuration:
 
 ```vim
 let g:silicon = {
-      \ 'theme':              'Dracula',
-      \ 'font':                  'Hack',
-      \ 'background':         '#aaaaff',
-      \ 'shadow-color':       '#555555',
-      \ 'line-pad':                   2,
-      \ 'pad-horiz':                 80,
-      \ 'pad-vert':                 100,
-      \ 'shadow-blur-radius':         0,
-      \ 'shadow-offset-x':            0,
-      \ 'shadow-offset-y':            0,
-      \ 'line-number':           v:true,
-      \ 'round-corner':          v:true,
-      \ 'window-controls':       v:true,
-      \ 'default-file-pattern'       '',
+      \   'theme':              'Dracula',
+      \   'font':                  'Hack',
+      \   'background':         '#AAAAFF',
+      \   'shadow-color':       '#555555',
+      \   'line-pad':                   2,
+      \   'pad-horiz':                 80,
+      \   'pad-vert':                 100,
+      \   'shadow-blur-radius':         0,
+      \   'shadow-offset-x':            0,
+      \   'shadow-offset-y':            0,
+      \   'line-number':           v:true,
+      \   'round-corner':          v:true,
+      \   'window-controls':       v:true,
       \ }
+```
+
+Images are by default saved to the working directory with a unique filename,
+you can change this filepath by setting:
+
+```vim
+let g:silicon['output'] = '~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png'
 ```
 
 To get the list of available themes, you can run this in the terminal:

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -161,9 +161,9 @@ endfun
 
 fun! s:cmd_output(path, flags)
   if !empty(a:path)
-    return ['--output', s:cmd_output_path(a:path, a:flags)]
+    return ['--output', s:set_extension(s:cmd_output_path(a:path, a:flags))]
   elseif !empty(g:silicon['default-file-pattern'])
-    return ['--output', s:cmd_file_pattern(a:path, a:flags)]
+    return ['--output', s:set_extension(s:cmd_file_pattern(a:path, a:flags))]
   elseif !empty(executable('xclip'))
     return ['--to-clipboard']
   el
@@ -185,21 +185,21 @@ fun! s:cmd_file_pattern(path, flags)
   let path = substitute(path, '{time:\(.\{-}\)}', {match -> strftime(match[1])}, 'g')
   let path = substitute(path, '{file:\(.\{-}\)}', {match -> expand(match[1])}, 'g')
   let path = fnamemodify(path, ':p')
-  return s:set_extension(path)
+  return path
 endfun
 
 fun! s:cmd_output_path(path, flags)
   let realpath = expand(a:path)
   if isdirectory(realpath)                     " /path/to/
     let filename = expand('%:t:r')
+    let date = strftime('%Y-%m-%d_%H:%M:%S')
     if !empty(filename)                        " Named source file
-      return realpath.'/'.filename.'.png'
+      return realpath.'/'.filename.'_'.date
     el                                         " Unnamed source file
-      let date = strftime('%Y-%m-%d_%H-%M-%S')
-      return realpath.'/silicon_'.date.'.png'
+      return realpath.'/silicon_'.date
     en
   el
-    return s:set_extension(realpath)           " /path/to/img.png
+    return realpath                            " /path/to/img.png
   en
 endfun
 
@@ -217,7 +217,7 @@ fun! s:infer_language()
 endfun
 
 fun! s:cmd_language(path, flags)
-  return ['--language', string(get(a:flags, 'language', s:infer_language()))]
+  return ['--language', get(a:flags, 'language', s:infer_language())]
 endfun
 
 fun! s:cmd_config(path, flags)
@@ -230,7 +230,7 @@ fun! s:cmd_config(path, flags)
           let flags += ['--no-'.key]
         en
       el
-        let flags += ['--'.key, string(val)]
+        let flags += ['--'.key, val]
       en
     en
   endfor

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -224,11 +224,11 @@ endfun
 
 " All possible flags that can be completed
 fun s:all_flags()
-  let s:all_flags = {}
+  let all_flags = {}
   for [key, val] in items(s:default)
-    let s:all_flags['--'.key] = val
+    let all_flags['--'.key] = val
   endfor
-  return s:all_flags
+  return all_flags
 endfun
 
 " Current flags that have been completed

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -214,26 +214,26 @@ fun! s:cmd(binary, args, config, spec)
   if !empty(errors)
     throw s:format_errors(errors)
   en
-  return [[a:binary] + s:cmd_flags(a:spec, config), config.output]
+  return [[a:binary] + s:args(a:spec, config), config.output]
 endfun
 
-" Info: Converts a:config parameters into flags
-fun! s:cmd_flags(spec, config)
-  let flags = []
+" Info: Converts a:config parameters into arguments
+fun! s:args(spec, config)
+  let args = []
   for [key, val] in items(a:config)
     let type = type(val)
     if type == v:t_bool
       let Default = a:spec[key][s:default]
       if (Default == v:false || type(Default) == v:t_func) && val == v:true
-        let flags += ['--'.key] " Enable, e.g. --to-clipboard
+        let args += ['--'.key] " Enable, e.g. --to-clipboard
       elseif Default == v:true && val == v:false
-        let flags += ['--no-'.key] " Disable, e.g. --no-window-controls
+        let args += ['--no-'.key] " Disable, e.g. --no-window-controls
       en
     el
-      let flags += ['--'.key, type == v:t_string? string(val) : val] " Set
+      let args += ['--'.key, type == v:t_string? string(val) : val] " Set
     en
   endfor
-  return flags
+  return args
 endfun
 
 " ======================== Plugin specific functions =========================

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -298,7 +298,8 @@ fun! s:complete_defaults(key, val)
 endfun
 
 const s:themes       = function('s:complete_themes')
-const s:fonts        = function('s:complete_fonts')
+const s:fonts        = function(executable('fc-list')?
+      \ 's:complete_fonts':'s:complete_defaults')
 const s:bools        = function('s:complete_bools')
 const s:filetypes    = function('s:complete_filetypes')
 const s:defaults     = function('s:complete_defaults')

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -50,18 +50,18 @@ fun! s:handler(channel_id, data, name)
 "   en
 endfun
 
-const s:job_options = {
-      \   'on_stdout': function('s:handler'),
-      \   'on_stderr': function('s:handler'),
-      \   'on_exit':   function('s:handler'),
-      \   'on_data':   function('s:handler'),
-      \ }
+const s:job_options = {}
+"       \   'on_stdout': function('s:handler'),
+"       \   'on_stderr': function('s:handler'),
+"       \   'on_exit':   function('s:handler'),
+"       \   'on_data':   function('s:handler'),
+"       \ }
 
 " ------------------------------ Error handling ------------------------------
 
 " Info: Prints a warning message
 fun! s:print_warning(msg)
-	echoh WarningMsg | echom "[Silicon - Warning]: ".a:msg | echoh None
+	echoh WarningMsg | echom '[Silicon - Warning]: '.a:msg | echoh None
 endfun
 
 " Info: Prints an error message
@@ -72,7 +72,7 @@ endfun
 
 " Info: Prints a silent info message
 fun! s:print_info(msg)
-	echom "[Silicon - Info]: ".a:msg
+	echom '[Silicon - Info]: '.a:msg
 endfun
 
 " Info: Formats a list of errors
@@ -85,7 +85,7 @@ endfun
 " Info: Either creates or derives a configuration based on a specification
 fun! s:configure(name, spec)
   if !exists(a:name)
-    let {a:name} = map(deepcopy(a:spec), "v:val[s:default]")
+    let {a:name} = map(copy(a:spec), "v:val[s:default]")
   el
     let config = {a:name}
     for [key, val] in items(a:spec)
@@ -200,26 +200,14 @@ endfun
 
 " ----------------------------- Command builder ------------------------------
 
-let s:cached_input = []
-let s:cached_output = v:null
-
-fun! s:cmd(binary, args, config, spec)
-  if s:cached_input != [a:args, a:config]
-    let s:cached_input = [a:args, a:config]
-    let s:cached_output = s:create_cmd(a:binary, a:args, a:config, a:spec)
-  en
-  return s:cached_output
-endfun
-
 " Info: Build a command
-fun! s:create_cmd(binary, args, config, spec)
-  let s:cached_input = [a:args, a:config]
+fun! s:cmd(binary, args, config, spec)
   let [path, flags, errors] = s:entered_flags(a:args, a:spec)
   if !empty(errors)
     throw s:format_errors(errors)
   en
   let flags.output = path
-  let config = deepcopy(a:config)
+  let config = copy(a:config)
   call s:override(config, flags)
   call s:expand(config)
   let errors = s:validate(a:binary, a:spec, config)
@@ -358,7 +346,7 @@ endfun
 
 " Info: Returns all flags that can be completed
 fun s:all_flags(spec)
-  let all_flags = map(deepcopy(a:spec), "v:val[s:default]")
+  let all_flags = map(copy(a:spec), "v:val[s:default]")
   call remove(all_flags, 'output') " Output is treated differently
   return all_flags
 endfun
@@ -399,7 +387,7 @@ endfun
 
 " Info: Returns remaining flags to-be completed
 fun! s:remaining_flags(all_flags, entered_flags)
-  let remaining_flags = deepcopy(a:all_flags)
+  let remaining_flags = copy(a:all_flags)
   for entered_flag in keys(a:entered_flags)
     if has_key(remaining_flags, entered_flag)
       call remove(remaining_flags, entered_flag)

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -230,7 +230,7 @@ fun! s:args(spec, config)
         let args += ['--no-'.key] " Disable, e.g. --no-window-controls
       en
     el
-      let args += ['--'.key, type == v:t_string? string(val) : val] " Set
+      let args += ['--'.key, val] " Set, e.g. --line-pad 2
     en
   endfor
   return args

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -21,21 +21,26 @@ let s:typename = [
       \ ]
 
 fun! s:on_stdout(chan_id, data, name)
-  echo 'stdout: '.string([a:chan_id, a:data, a:name])
+"   echomsg 'stdout: '.string([a:chan_id, a:data, a:name])
 endfun
 
 fun! s:on_stderr(chan_id, data, name)
-  echo 'stderr: '.string([a:chan_id, a:data, a:name])
+"   echomsg 'stderr: '.string([a:chan_id, a:data, a:name])
 endfun
 
 fun! s:on_exit(chan_id, data, name)
-  echo 'exit: '.string([a:chan_id, a:data, a:name])
+"   echomsg 'exit: '.string([a:chan_id, a:data, a:name])
+endfun
+
+fun! s:on_data(chan_id, data, name)
+"   echomsg 'data: '.string([a:chan_id, a:data, a:name])
 endfun
 
 let s:job_options = {
           \ "on_stdout": function("s:on_stdout"),
           \ "on_stderr": function("s:on_stderr"),
           \ "on_exit":   function("s:on_exit"),
+          \ "on_data":   function("s:on_data"),
           \ }
 
 " Job-dispatch
@@ -241,12 +246,12 @@ fun! silicon#generate(line1, line2, ...)
     let [path, flags] = s:entered_flags(a:000)
     let cmd = s:cmd(path, flags)
     let lines = join(getline(a:line1, a:line2), "\n")
-    call system('echo "'.lines.'" | '.join(cmd))
+    echomsg string(cmd)
     call s:dispatch(cmd, lines)
-    echo '[Silicon - Success]: Image Generated'
+    echomsg '[Silicon - Success]: Image Generated'
   catch
     let v:errmsg = '[Silicon - Error]: '.v:exception
-    echohl ErrorMsg | echo v:errmsg | echohl None
+    echohl ErrorMsg | echomsg v:errmsg | echohl None
   endtry
 endfun
 
@@ -260,10 +265,10 @@ fun! silicon#generate_highlighted(line1, line2, ...)
     let cmd = s:cmd(path, flags) + ['--highlight-lines', a:line1.'-'.a:line2]
     let lines = join(getline('1', '$'), "\n")
     call s:dispatch(cmd, lines)
-    echo '[Silicon - Success]: Highlighted Image Generated'
+    echomsg '[Silicon - Success]: Highlighted Image Generated'
   catch
     let v:errmsg = '[Silicon - Error]: '.v:exception
-    echohl ErrorMsg | echo v:errmsg | echohl None
+    echohl ErrorMsg | echomsg v:errmsg | echohl None
   endtry
 endfun
 

--- a/doc/silicon.txt
+++ b/doc/silicon.txt
@@ -38,7 +38,6 @@ to install silicon, which is most easily done using cargo:
 COMMANDS                                                *vim-silicon-commands*
 
     1. Silicon ........................................... |:Silicon|
-    2. SiliconHighlight .................................. |:SiliconHighlight|
 
 ------------------------------------------------------------------------------
                                                                     *:Silicon*
@@ -59,6 +58,10 @@ Examples:
     " Generate an image of the current visual line selection
     " and write it to /path/to/output.png
     :'<,'>Silicon /path/to/output.png
+
+    " Generate an image of the current buffer, with the current visual line
+    " selection highlighted.
+    :'<,'>Silicon! /path/to/output.png
 >
 
 ------------------------------------------------------------------------------
@@ -70,8 +73,8 @@ visual line selection highlighted.
 ==============================================================================
 OPTIONS                                                  *vim-silicon-options*
 
-    g:silicon ............................... |g:silicon|
-    g:silicon['default-file-name'] .......... |g:silicon['default-file-name']|
+    g:silicon .......................................... |g:silicon|
+    g:silicon['output'] ................................ |g:silicon['output']|
 
 ------------------------------------------------------------------------------
                                                                    *g:silicon*
@@ -79,20 +82,19 @@ Type: dict ~
 Default: ~
 >
     let g:silicon = {
-          \ 'theme':              'Dracula',
-          \ 'font':                  'Hack',
-          \ 'background':         '#aaaaff',
-          \ 'shadow-color':       '#555555',
-          \ 'line-pad':                   2,
-          \ 'pad-horiz':                 80,
-          \ 'pad-vert':                 100,
-          \ 'shadow-blur-radius':         0,
-          \ 'shadow-offset-x':            0,
-          \ 'shadow-offset-y':            0,
-          \ 'line-number':           v:true,
-          \ 'round-corner':          v:true,
-          \ 'window-controls':       v:true,
-          \ 'default-file-pattern'       '',
+          \   'theme':              'Dracula',
+          \   'font':                  'Hack',
+          \   'background':         '#AAAAFF',
+          \   'shadow-color':       '#555555',
+          \   'line-pad':                   2,
+          \   'pad-horiz':                 80,
+          \   'pad-vert':                 100,
+          \   'shadow-blur-radius':         0,
+          \   'shadow-offset-x':            0,
+          \   'shadow-offset-y':            0,
+          \   'line-number':           v:true,
+          \   'round-corner':          v:true,
+          \   'window-controls':       v:true,
           \ }
 >
 
@@ -105,7 +107,7 @@ To get the list of available themes, you can run this in the terminal:
 For more details about options, please see https://github.com/Aloxaf/silicon.
 
 ------------------------------------------------------------------------------
-                                           *g:silicon['default-file-pattern']*
+                                                         *g:silicon['output']*
 
 If set to a non-empty string, it'll be used as the default filename when
 |:Silicon| is called with no arguments. Note that this means you could no
@@ -115,8 +117,7 @@ It's possible to embed a timestamp into the filename by using the
 `{time:<strftime() specifier>}` format. As an example:
 
 >
-    let g:silicon['default-file-pattern'] =
-            \ '~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png'
+    let g:silicon['output'] = '~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png'
 >
 
 This might result in the file: `~/images/silicon-2019-08-10-164233.png`.

--- a/plugin/silicon.vim
+++ b/plugin/silicon.vim
@@ -7,12 +7,12 @@
 com!
   \ -range=%
   \ -nargs=?
-  \ -complete=dir
+  \ -complete=customlist,silicon#complete()
   \ Silicon call silicon#generate(<line1>, <line2>, <f-args>)
 
 com!
   \ -range
   \ -nargs=?
-  \ -complete=dir
+  \ -complete=customlist,silicon#complete()
   \ SiliconHighlight call silicon#generate_highlighted(<line1>, <line2>, <f-args>)
 

--- a/plugin/silicon.vim
+++ b/plugin/silicon.vim
@@ -7,12 +7,12 @@
 com!
   \ -range=%
   \ -nargs=?
-  \ -complete=customlist,silicon#complete()
+  \ -complete=customlist,silicon#complete
   \ Silicon call silicon#generate(<line1>, <line2>, <f-args>)
 
 com!
   \ -range
   \ -nargs=?
-  \ -complete=customlist,silicon#complete()
+  \ -complete=customlist,silicon#complete
   \ SiliconHighlight call silicon#generate_highlighted(<line1>, <line2>, <f-args>)
 

--- a/plugin/silicon.vim
+++ b/plugin/silicon.vim
@@ -1,20 +1,20 @@
 " vim: et sw=2 sts=2
 
 " Plugin:      https://github.com/segeljakt/vim-silicon
-" Description: Create beautiful images of your source code.
+" Description: Create beautiful images of source code.
 " Maintainer:  Klas Segeljakt <http://github.com/segeljakt>
 
 com!
-  \ -range=%
+  \ -bang
+  \ -range
   \ -nargs=*
   \ -complete=customlist,silicon#complete
   \ Silicon
-  \ call silicon#generate(<line1>, <line2>, <f-args>)
+  \ call silicon#generate(<bang>0, <line1>, <line2>, <f-args>)
 
 com!
   \ -range
   \ -nargs=*
-  \ -complete=customlist,silicon#complete
   \ SiliconHighlight
-  \ call silicon#generate_highlighted(<line1>, <line2>, <f-args>)
+  \ echoerr ':SiliconHighlight is deprecated, use :Silicon! instead'
 

--- a/plugin/silicon.vim
+++ b/plugin/silicon.vim
@@ -6,13 +6,13 @@
 
 com!
   \ -range=%
-  \ -nargs=?
+  \ -nargs=*
   \ -complete=customlist,silicon#complete
   \ Silicon call silicon#generate(<line1>, <line2>, <f-args>)
 
 com!
   \ -range
-  \ -nargs=?
+  \ -nargs=*
   \ -complete=customlist,silicon#complete
   \ SiliconHighlight call silicon#generate_highlighted(<line1>, <line2>, <f-args>)
 

--- a/plugin/silicon.vim
+++ b/plugin/silicon.vim
@@ -8,11 +8,13 @@ com!
   \ -range=%
   \ -nargs=*
   \ -complete=customlist,silicon#complete
-  \ Silicon call silicon#generate(<line1>, <line2>, <f-args>)
+  \ Silicon
+  \ call silicon#generate(<line1>, <line2>, <f-args>)
 
 com!
   \ -range
   \ -nargs=*
   \ -complete=customlist,silicon#complete
-  \ SiliconHighlight call silicon#generate_highlighted(<line1>, <line2>, <f-args>)
+  \ SiliconHighlight
+  \ call silicon#generate_highlighted(<line1>, <line2>, <f-args>)
 

--- a/plugin/silicon.vim
+++ b/plugin/silicon.vim
@@ -6,7 +6,7 @@
 
 com!
   \ -bang
-  \ -range
+  \ -range=%
   \ -nargs=*
   \ -complete=customlist,silicon#complete
   \ Silicon

--- a/tests/minimal-vimrc
+++ b/tests/minimal-vimrc
@@ -1,0 +1,3 @@
+call plug#begin('~/.vim/plugged')
+Plug 'segeljakt/vim-silicon'
+call plug#end()

--- a/tests/suite.vim
+++ b/tests/suite.vim
@@ -1,0 +1,27 @@
+" <This line will be generated>
+
+" Setup
+
+source ./minimal-vimrc
+
+" Tests (Might need to execute manually)
+
+Silicon ./test-img-1.png
+      \ --background=#FFFFFF
+      \ --font=Arial
+      \ --language=java
+      \ --line-number=true
+      \ --line-pad=1
+      \ --pad-horiz=500
+      \ --pad-vert=500
+      \ --round-corner=true
+      \ --shadow-blur-radius=0
+      \ --shadow-color=#555555
+      \ --shadow-offset-x=0
+      \ --shadow-offset-y=0
+      \ --theme=1337
+
+Silicon ./test-img-2.png
+
+Silicon! ./test-img-3.png
+


### PR DESCRIPTION
From [Two_Souls](https://www.reddit.com/r/vim/comments/ckeo3x/vimsilicon_a_plugin_for_generating_images_of/ewc5cal/?context=3):

> Thanks for this. I've started using this mainly for sharing code with colleagues when discussing code/features/helping. I was just wondering whether arguments can be passed to the call within Vim more specifically the --language argument?

This PR is a WIP which will add the ability to override configuration parameters when executing `:Silicon` at the command line. For example:
```vim
:Silicon ~/Desktop/output.png --language=python
```
The parameters will also have custom completions.