### PR TITLE
Version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ Plug 'segeljakt/vim-silicon'
 
 # Commands
 
-The available commands are `Silicon`, and `SiliconHighlight`:
+This plugin provides a single command `Silicon`:
 
 ```vim
 " Generate an image of the current buffer and write it to /path/to/output.png
 :Silicon /path/to/output.png
+
+" Generate an image of the current buffer and write it to /path/to/output.png and clipboard.
+:Silicon /path/to/output.png --to-clipboard
 
 " Generate an image of the current buffer and write it to /path/to/<filename>.png
 :Silicon /path/to/
@@ -42,10 +45,8 @@ The available commands are `Silicon`, and `SiliconHighlight`:
 :'<,'>Silicon /path/to/output.png
 
 " Generate an image of the current buffer, with the current visual line selection highlighted.
-:'<,'>SiliconHighlight /path/to/output.png
+:'<,'>Silicon! /path/to/output.png
 ```
-
-If no `/path/to/output.png` is specified, then the generated image is copied to clipboard. However, this feature is only supported on Linux at the moment.
 
 # Options
 
@@ -53,21 +54,27 @@ This is the default configuration:
 
 ```vim
 let g:silicon = {
-      \ 'theme':              'Dracula',
-      \ 'font':                  'Hack',
-      \ 'background':         '#aaaaff',
-      \ 'shadow-color':       '#555555',
-      \ 'line-pad':                   2,
-      \ 'pad-horiz':                 80,
-      \ 'pad-vert':                 100,
-      \ 'shadow-blur-radius':         0,
-      \ 'shadow-offset-x':            0,
-      \ 'shadow-offset-y':            0,
-      \ 'line-number':           v:true,
-      \ 'round-corner':          v:true,
-      \ 'window-controls':       v:true,
-      \ 'default-file-pattern'       '',
+      \   'theme':              'Dracula',
+      \   'font':                  'Hack',
+      \   'background':         '#AAAAFF',
+      \   'shadow-color':       '#555555',
+      \   'line-pad':                   2,
+      \   'pad-horiz':                 80,
+      \   'pad-vert':                 100,
+      \   'shadow-blur-radius':         0,
+      \   'shadow-offset-x':            0,
+      \   'shadow-offset-y':            0,
+      \   'line-number':           v:true,
+      \   'round-corner':          v:true,
+      \   'window-controls':       v:true,
       \ }
+```
+
+Images are by default saved to the working directory with a unique filename,
+you can change this filepath by setting:
+
+```vim
+let g:silicon['output'] = '~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png'
 ```
 
 To get the list of available themes, you can run this in the terminal:
@@ -76,7 +83,44 @@ To get the list of available themes, you can run this in the terminal:
 silicon --list-themes
 ```
 
+Silicon internally uses [`bat`'s](https://github.com/sharkdp/bat) themes and syntaxes. To get the list of supported languages, you could:
+
+```sh
+cargo install bat
+bat --list-languages
+```
+
 For more details about options, see https://github.com/Aloxaf/silicon.
+
+## Advanced Configuration
+
+Instead of assigning values to flags in g:silicon, you can assign functions which expand into values right before generating the images.
+
+For example, to save images into different directories depending on whether you are at work or not:
+
+```vim
+let s:workhours = {
+      \ 'Monday':    [8, 16],
+      \ 'Tuesday':   [9, 17],
+      \ 'Wednesday': [9, 17],
+      \ 'Thursday':  [9, 17],
+      \ 'Friday':    [9, 15],
+      \ }
+
+function! s:working()
+    let day = strftime('%u')
+    if has_key(s:workhours, day)
+      let hour = strftime('%H')
+      let [start_hour, stop_hour] = s:workhours[day]
+      if start_hour <= hour && hour <= stop_hour
+        return "~/Work-Snippets/"
+      endif
+    endif
+    return "~/Personal-Snippets/"
+endfunction
+
+let g:silicon['output'] = function('s:working')
+```
 
 # Credits
 

--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -1,15 +1,15 @@
 " vim: et sw=2 sts=2
 
 " Plugin:      https://github.com/segeljakt/vim-silicon
-" Description: Create beautiful images of your source code.
+" Description: Create beautiful images of source code.
 " Maintainer:  Klas Segeljakt <http://github.com/segeljakt>
 
 if exists('s:autoloaded') | finish | el | let s:autoloaded = v:true | en
 
-" Plugin-independent Helpers
+" ====================== Plugin-Independent Functions ========================
 
-" Mapping from type-number to type-name
-let s:typename = [
+" Info: Mapping from type-number to type-name
+const s:typename = [
       \ 'number',
       \ 'string',
       \ 'func',
@@ -20,204 +20,472 @@ let s:typename = [
       \ 'null',
       \ ]
 
-" Job-dispatch
+" Info: Converts a number into a boolean
+fun! s:nr2bool(number)
+  return  a:number == 0 ? v:false :
+        \ a:number == 1 ? v:true :
+        \ a:number
+endfun
+
+" Info: Parses a string into a vim-expression
+fun! s:parse_expr(str)
+  return  a:str == 'true' ? v:true :
+        \ a:str == 'false' ? v:false :
+        \ a:str =~ '\v^[[:digit:]]+$' ? str2nr(a:str) :
+        \ a:str
+endfun
+
+" ------------------------- Vim/Neovim Compatibility -------------------------
+
+" Info: Starts a:cmd as a job and passes a:data as input to it
 if has('nvim')
-  fun! s:dispatch(cmd, lines)
-    let id = jobstart(a:cmd)
-    call chansend(id, a:lines)
+  fun! s:run(cmd, data)
+    let id = jobstart(a:cmd, s:job_options)
+    call chansend(id, a:data)
     call chanclose(id)
   endfun
 el
-  fun! s:dispatch(cmd, lines)
-    let id = job_start(a:cmd)
-    call ch_sendraw(id, a:lines)
+  fun! s:run(cmd, data)
+    let id = job_start(a:cmd, s:job_options)
+    call ch_sendraw(id, a:data)
     call ch_close(id)
   endfun
 en
 
-" First, check that silicon is installed. Then, check for unexpected keys and
-" type mismatches in a:config, using a:default as reference. If any are found,
-" an exception is thrown.
-fun! s:validate(config, default)
-  if empty(executable('silicon'))
-    throw 'vim-silicon requires `silicon` to be installed. '
-          \ .'Please refer to the installation instructions in the README.md.'
-  en
-  let errors = []
-  for [key, val] in items(a:config)
-    if !has_key(a:default, key)
-      let errors += ['Unexpected key '.string(key)]
-    el
-      let default_val = a:default[key]
-      let found = type(val)
-      let expected = type(default_val)
-      if found != expected
-        let errors += [
-              \ 'Type mismatch in key '.string(key)
-              \ .', found '.string(s:typename[found])
-              \ .', expected '.string(s:typename[expected])
-              \ .', e.g. '.string(default_val)
-              \ ]
-      en
+" Info: Callback for job
+fun! s:handler(channel_id, data, name)
+  if s:debug_mode_enabled()
+    if a:name == 'stdout'
+      call s:print_debug('stdout: '.join(a:data))
+    if a:name == 'stderr'
+      call s:print_debug('stderr: '.join(a:data))
+    elseif a:name == 'exit'
+      call s:print_debug('exited')
+    elseif a:name == 'data'
+      call s:print_debug('data')
     en
-  endfor
-  if !empty(errors)
-    let sep = "\n  - "
-    throw sep + join(errors, sep)
   en
 endfun
 
-" Creates/derives a configuration based on a default configuration
-fun! s:configure(name, default)
+const s:job_options = {
+      \   'on_stderr': function('s:handler'),
+      \   'stderr_buffered': 1,
+      \ }
+
+" ------------------------------ Error handling ------------------------------
+
+" Info: Prints a warning message
+fun! s:print_success(msg)
+  echom '[Silicon - Success]: '.a:msg
+endfun
+
+" Info: Prints a warning message
+fun! s:print_warning(msg)
+	echoh WarningMsg | echom '[Silicon - Warning]: '.a:msg | echoh None
+endfun
+
+" Info: Prints an error message
+fun! s:print_error(msg)
+  let v:errmsg = '[Silicon - Error]: '.v:exception
+  echoh ErrorMsg | echom v:errmsg | echoh None
+endfun
+
+" Info: Prints a silent info message
+fun! s:print_debug(msg)
+	echom '[Silicon - Debug]: '.a:msg
+endfun
+
+" Info: Formats a list of errors
+fun! s:format_errors(errors)
+  return "\n  - " . join(a:errors, "\n  - ")
+endfun
+
+" Info: Returns true if debug mode is enabled
+fun! s:debug_mode_enabled()
+  return get(g:, 'silicon#debug', v:false)
+endfun
+
+fun! s:throw_if_nonempty(errors)
+  if !empty(a:errors)
+    throw s:format_errors(a:errors)
+  en
+endfun
+
+" ----------------------------- Configuration ------------------------------
+
+" Info: Either creates or derives a configuration based on a specification
+fun! s:configure(name, spec)
   if !exists(a:name)
-    let {a:name} = a:default
+    let {a:name} = map(copy(a:spec), "v:val[s:default]")
   el
     let config = {a:name}
-    for [key, val] in items(a:default)
-      if !has_key(config, key)
-        let config[key] = val
+    for [key, val] in items(a:spec)
+      if !has_key(config, key) && val[s:default] != v:null
+        let config[key] = val[s:default]
       en
     endfor
   en
 endfun
 
-" Default configuration
-let s:default_cmd = {
-      \   'theme':                'Dracula',
-      \   'font':                    'Hack',
-      \   'background':           '#aaaaff',
-      \   'shadow-color':         '#555555',
-      \   'line-pad':                     2,
-      \   'pad-horiz':                   80,
-      \   'pad-vert':                   100,
-      \   'shadow-blur-radius':           0,
-      \   'shadow-offset-x':              0,
-      \   'shadow-offset-y':              0,
-      \   'line-number':             v:true,
-      \   'round-corner':            v:true,
-      \   'window-controls':         v:true,
-      \ }
-
-let s:default_vim = {
-      \   'default-file-pattern':        '',
-      \ }
-
-let s:default = extend(copy(s:default_cmd), s:default_vim)
-
-call s:configure('g:silicon', s:default)
-
-" Silicon bindings
-fun! s:cmd(argc, argv)
-  return ['silicon']
-        \ + s:cmd_output(a:argc, a:argv)
-        \ + s:cmd_language(a:argc, a:argv)
-        \ + s:cmd_config(a:argc, a:argv)
-endfun
-
-fun! s:cmd_output(argc, argv)
-  if a:argc > 0
-    return ['--output', s:cmd_output_path(a:argc, a:argv)]
-  elseif !empty(g:silicon['default-file-pattern'])
-    return ['--output', s:cmd_output_pattern(a:argc, a:argv)]
-  elseif !empty(executable('xclip'))
-    return ['--to-clipboard']
-  el
-    throw 'Copying to clipboard is only supported on Linux with xclip installed. '
-          \ .'Please specify a path instead.'
+" Info: Identifies and warns about deprecated features
+fun! s:deprecate(config)
+  if has_key(a:config, 'default-file-pattern')
+    if s:debug_mode_enabled()
+      call s:print_warning('"default-file-pattern" is deprecated, '
+            \ .'please use "output" instead')
+    en
+    let a:config['output'] = remove(a:config, 'default-file-pattern')
   en
 endfun
 
-fun! s:set_extension(path)
-  if !empty(fnamemodify(a:path, ':e'))
-    return a:path
-  el
-    return a:path.'.png'
-  en
+" Info: Overrides user a:config with command-line a:flags
+fun! s:override(config, flags)
+  for [key, val] in items(a:flags)
+    let a:config[key] = val
+  endfor
 endfun
 
-fun! s:cmd_output_pattern(argc, argv)
-  let path = g:silicon['default-file-pattern']
-  let path = substitute(path, '{time:\(.\{-}\)}', {match -> strftime(match[1])}, 'g')
-  let path = substitute(path, '{file:\(.\{-}\)}', {match -> expand(match[1])}, 'g')
+" Info: Expands values in the user a:config by calling functions and expanding paths
+" if functions return numbers (0 and 1) where booleans are expected, make a conversion
+fun! s:expand(config, spec)
+  call map(a:config, "type(v:val) == v:t_func ? call(v:val, []) : v:val")
+  call map(a:config, "a:spec[v:key][s:type] == v:t_bool && type(v:val) == v:t_number ?"
+        \ ."s:nr2bool(v:val) : v:val")
+  let a:config['output'] = simplify(s:expand_path(a:config['output']))
+endfun
+
+" Info: Expands a a:path variable
+" e.g. ~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png
+" into ~/images/silicon-2019-08-10-164233.png
+fun! s:expand_path(path)
+  let path = substitute(a:path, '\v\{time:(.{-})\}', '\=strftime(submatch(1))', 'g')
+  let path = substitute(path, '\v\{file:(.{-})\}', '\=expand(submatch(1))', 'g')
   let path = fnamemodify(path, ':p')
-  return s:set_extension(path)
-endfun
-
-fun! s:cmd_output_path(argc, argv)
-  let path = expand(a:argv[0])
-  if isdirectory(path)                         " /path/to/
-    let filename = expand('%:t:r')
-    if !empty(filename)                        " Named source file
-      return path.'/'.filename.'.png'
-    el                                         " Unnamed source file
-      let date = strftime('%Y-%m-%d_%H-%M-%S')
-      return path.'/silicon_'.date.'.png'
-    en
+  if isdirectory(path)
+    return path.'/'.s:new_filename()
+  elseif empty(fnamemodify(a:path, ':e'))
+    return path.'.png'
   el
-    return s:set_extension(path)               " /path/to/img.png
+    return path
   en
 endfun
 
-fun! s:cmd_language(argc, argv)
-  if !empty(&ft)
-    return ['--language', &ft]
-  el
-    let ext = expand('%:e')
-    if !empty(ext)
-      return ['--language', ext]
+" Info: Generates a filename
+fun! s:new_filename()
+  let file = expand('%:t:r')
+  let date = strftime('%Y-%m-%d_%H:%M:%S')
+  return (empty(file) ? 'silicon' : file).'_'.date.'.png'
+endfun
+
+" Info: Checks for binary installation, and inconsistencies between the user
+" a:config and internal a:spec
+fun! s:validate(binary, config, spec)
+  let errors = []
+  if executable(a:binary) != 1
+    let errors += ['vim-'.a:binary.' requires `'.a:binary.'` to be '
+          \ .'installed and added to the $PATH. Please refer to the '
+          \ .'installation instructions in the README.md.']
+  en
+  for [key, val] in items(a:config)
+    if !has_key(a:spec, key)
+      let errors += ['Unexpected key in g:'.a:binary.': '.string(key)]
     el
-      return ['--language', 'txt']
-    en
-  en
-endfun
-
-fun! s:cmd_config(argc, argv)
-  let flags = []
-  for [key, val] in items(g:silicon)
-    if has_key(s:default_cmd, key)
-      if type(val) == type(v:false)
-        if val == v:false
-          let flags += ['--no-'.key]
-        en
-      el
-        let flags += ['--'.key, val]
+      let [found, expected] = [type(val), a:spec[key][s:type]]
+      if found != expected && found != v:t_func
+        let errors += ['Type mismatch in g:'.a:binary.' for key "'.key.'"'
+              \ .': found `'.s:typename[found].'`'
+              \ .', expected `'.s:typename[expected].'`'
+              \ .', e.g. '.string(a:spec[key][s:default])]
       en
     en
   endfor
-  return flags
+  return errors
 endfun
 
-" Exposed API
-fun! silicon#generate(line1, line2, ...)
-  try
-    if mode() != 'n' && visualmode() != 'V'
-      throw 'Command can only be called from Normal or Visual Line mode.'
+" -------------------------- Infer values for flags --------------------------
+
+" Info: Infer the --output flag
+fun! s:infer_output()
+  return getcwd().'/'.s:new_filename()
+endfun
+
+" Info: Infer the --language flag
+fun! s:infer_language()
+  if !empty(&ft)
+    return &ft
+  el
+    let ext = expand('%:e')
+    if !empty(ext)
+      return ext
+    el
+      return 'txt'
     en
-    call s:validate(g:silicon, s:default)
-    let cmd = s:cmd(a:0, a:000)
-    let lines = join(getline(a:line1, a:line2), "\n")
-    call s:dispatch(cmd, lines)
-    echo '[Silicon - Success]: Image Generated'
+  en
+endfun
+
+const s:os = has('win64') || has('win32') || has('win16') ? 'Windows' :
+      \ has('mac') || has('macunix') || has('gui_mac') ? 'Darwin' :
+      \ substitute(system('uname'), '\n', '', '')
+
+" Info: Infer the --to-clipboard flag
+fun! s:infer_to_clipboard()
+  return !empty(executable('xclip')) || s:os ==# 'Darwin'
+endfun
+
+" ----------------------------- Command builder ------------------------------
+
+" Info: Converts a:config parameters into arguments
+fun! s:args(config, spec)
+  let args = []
+  for [key, val] in items(a:config)
+    let type = type(val)
+    if type == v:t_bool
+      let Default = a:spec[key][s:default]
+      if val == v:true && (Default == v:false || type(Default) == v:t_func)
+        let args += ['--'.key] " Enable, e.g. --to-clipboard
+      elseif val == v:false && Default == v:true
+        let args += ['--no-'.key] " Disable, e.g. --no-window-controls
+      en
+    el
+      let args += ['--'.key, val] " Set, e.g. --line-pad 2
+    en
+  endfor
+  return args
+endfun
+
+" ======================== Plugin specific functions =========================
+
+" --------------------------- Completion functions ---------------------------
+
+" Info: Theme completions
+fun! s:complete_themes(key, val)
+	return filter(systemlist('silicon --list-themes'), 'v:val =~? "^".a:val')
+endfun
+
+" Info: Font completions
+fun! s:complete_fonts(key, val)
+  return map(filter(systemlist('fc-list : family'), 'v:val =~? "^".a:val'),
+        \ 'escape(v:val, " ")')
+endfun
+
+" Info: Bool completions
+fun! s:complete_bools(key, val)
+  return filter([v:true, v:false], 'v:val =~? "^".a:val')
+endfun
+
+" Info: Language completions
+fun! s:complete_filetypes(key, val)
+  return getcompletion(a:val, 'filetype')
+endfun
+
+" Info: Path completions
+fun! s:complete_paths(key, val)
+  return getcompletion(a:val, 'dir') + ['./', '../']
+endfun
+
+" Info: Default completion function
+fun! s:complete_defaults(key, val)
+  let current = get(g:silicon, a:key, '')
+  let default = s:silicon[a:key][s:default]
+  let completions = (current == default) ? [default] : [current, default]
+  return filter(completions, 'v:val =~? "^".a:val')
+endfun
+
+const s:themes       = function('s:complete_themes')
+const s:fonts        = function(executable('fc-list') ?
+      \ 's:complete_fonts':'s:complete_defaults')
+const s:bools        = function('s:complete_bools')
+const s:filetypes    = function('s:complete_filetypes')
+const s:defaults     = function('s:complete_defaults')
+const s:paths        = function('s:complete_paths')
+
+const s:to_clipboard = function('s:infer_to_clipboard')
+const s:language     = function('s:infer_language')
+const s:output       = function('s:infer_output')
+
+" ---------------------- Internal config specification -----------------------
+
+const [s:type, s:default, s:compfun] = range(0, 2) " Column labels
+const s:silicon = {
+      \   'theme':              [ v:t_string,      'Dracula',    s:themes ],
+      \   'font':               [ v:t_string,         'Hack',     s:fonts ],
+      \   'background':         [ v:t_string,      '#AAAAFF',  s:defaults ],
+      \   'shadow-color':       [ v:t_string,      '#555555',  s:defaults ],
+      \   'line-pad':           [ v:t_number,              2,  s:defaults ],
+      \   'pad-horiz':          [ v:t_number,             80,  s:defaults ],
+      \   'pad-vert':           [ v:t_number,            100,  s:defaults ],
+      \   'shadow-blur-radius': [ v:t_number,              0,  s:defaults ],
+      \   'shadow-offset-x':    [ v:t_number,              0,  s:defaults ],
+      \   'shadow-offset-y':    [ v:t_number,              0,  s:defaults ],
+      \   'line-number':        [   v:t_bool,         v:true,     s:bools ],
+      \   'round-corner':       [   v:t_bool,         v:true,     s:bools ],
+      \   'window-controls':    [   v:t_bool,         v:true,     s:bools ],
+      \   'to-clipboard':       [   v:t_bool, s:to_clipboard,     s:bools ],
+      \   'language':           [ v:t_string,     s:language, s:filetypes ],
+      \   'output':             [ v:t_string,       s:output,     s:paths ],
+      \ }
+
+call s:configure('g:silicon', s:silicon)
+call s:deprecate(g:silicon)
+
+fun! s:read_attributes(bang, line1, line2)
+    let errors = []
+    if !a:bang 
+      let lines = join(getline(a:line1, a:line2), "\n")
+      let suffix = []
+    el
+      if a:line1 == 1 && a:line2 == line('$')
+        let errors += [
+              \ 'Specify a sub-range to highlight using Visual Line mode.'
+              \ ]
+      en
+      let [line1, line2] = [a:line1, a:line2]
+      if line2 == line('$')
+        let line2 -= 1
+        if line1 == line('$')
+          let line1 -= 1
+        en
+      en
+      let lines = join(getline(0, '$'), "\n")
+      let suffix = ['--highlight-lines', line1.'-'.line2]
+    en
+    return [lines, suffix, errors]
+endfun
+
+" =============================== External API ===============================
+
+" Info: Generates an image of code which represents lines a:line1 to a:line2
+" of the current buffer. If <bang> is supplied, then the generated image will
+" instead represent the current buffer with a:line1 to a:line2 highlighted.
+fun! silicon#generate(bang, line1, line2, ...)
+  try
+    let [lines, suffix, errors] = s:read_attributes(a:bang, a:line1, a:line2)
+    call s:throw_if_nonempty(errors)
+
+    let [path, flags, errors] = s:entered_flags(a:000, s:silicon)
+    call s:throw_if_nonempty(errors)
+
+    if !empty(path)
+      let flags['output'] = path
+    en
+
+    let silicon = copy(g:silicon)
+    call s:override(silicon, flags)
+    call s:expand(silicon, s:silicon)
+
+    let errors = s:validate('silicon', silicon, s:silicon)
+    call s:throw_if_nonempty(errors)
+
+    let messages = []
+
+    if !empty(silicon['to-clipboard'])
+      let tmp = remove(silicon, 'output')
+      call s:run(['silicon'] + s:args(silicon, s:silicon) + suffix, lines)
+      let silicon['output'] = tmp
+      let messages += ['copied to clipboard']
+    en
+
+    if !empty(silicon['output'])
+      let tmp = remove(silicon, 'to-clipboard')
+      call s:run(['silicon'] + s:args(silicon, s:silicon) + suffix, lines)
+      let silicon['to-clipboard'] = tmp
+      let messages += ['written to '.silicon['output']]
+    en
+
+    call s:print_success('Generated image '.join(messages, ' and '))
+
+    if s:debug_mode_enabled()
+      let @+ = join(cmd + suffix)
+      call s:print_debug('Command executed: '.string(cmd + suffix))
+      call s:print_debug('With piped input: '.string(lines))
+      call s:print_debug('Copied command to clipboard: '.@+)
+    en
   catch
-    let v:errmsg = '[Silicon - Error]: '.v:exception
-    echohl ErrorMsg | echo v:errmsg | echohl None
+    call s:print_error(v:exception)
   endtry
 endfun
 
-fun! silicon#generate_highlighted(line1, line2, ...)
-  try
-    if visualmode() != 'V'
-      throw 'Command can only be called from Visual Line mode.'
-    en
-    call s:validate(g:silicon, s:default)
-    let cmd = s:cmd(a:0, a:000)
-          \ + ['--highlight-lines', a:line1.'-'.a:line2]
-    let lines = join(getline('1', '$'), "\n")
-    call s:dispatch(cmd, lines)
-    echo '[Silicon - Success]: Highlighted Image Generated'
-  catch
-    let v:errmsg = '[Silicon - Error]: '.v:exception
-    echohl ErrorMsg | echo v:errmsg | echohl None
-  endtry
+" =============================== Completions ================================
+
+" Info: Returns all flags that can be completed
+fun s:all_flags(spec)
+  let all_flags = map(copy(a:spec), "v:val[s:default]")
+  call remove(all_flags, 'output') " Output is treated differently
+  return all_flags
 endfun
 
+" Info: Returns current path and flags that have been completed, and any
+" kind of errors that might have occurred
+fun! s:entered_flags(args, spec)
+  let [entered_path, entered_flags, errors] = ['', {}, []]
+  for arg in a:args
+    let matches = matchlist(arg, '\v^--([[:lower:]\-]+)\=(.+)$')
+    if !empty(matches)
+      let [key, val] = matches[1:2]
+      if has_key(a:spec, key)
+        let entered_flags[key] = (key == 'theme' || key == 'font') ?
+              \ val : s:parse_expr(val)
+      el
+        let errors += ['Undefined command-line flag: '.string('--'.key)]
+      en
+    elseif arg !~ '^-'
+      if empty(entered_path)
+        let entered_path = arg
+      el
+        let errors += ['Multiple output paths specified on command-line: '
+              \ .string(entered_path).' and '.string(arg)]
+      en
+    el
+      let errors += ['Failed to parse command-line argument: '.string(arg)]
+    en
+  endfor
+  return [entered_path, entered_flags, errors]
+endfun
+
+" Info: Returns remaining flags to-be completed
+fun! s:remaining_flags(all_flags, entered_flags)
+  let remaining_flags = copy(a:all_flags)
+  for entered_flag in keys(a:entered_flags)
+    if has_key(remaining_flags, entered_flag)
+      call remove(remaining_flags, entered_flag)
+    en
+  endfor
+  return remaining_flags
+endfun
+
+" Info: Completion function for :Silicon that completes:
+" 1. Output paths e.g. :Silicon foo/bar/baz
+" 2. Flag keys    e.g. :Silicon foo/bar/baz --flag
+" 3. Flag =       e.g. :Silicon foo/bar/baz --flag=
+" 4. Flag values  e.g. :Silicon foo/bar/baz --flag=123
+" Only remaining, i.e. un-entered, output paths/flags are completed
+fun! silicon#complete(arglead, cmdline, cursorpos)
+  let args = split(a:cmdline)[1:]
+  let all_flags = s:all_flags(s:silicon)
+  let [entered_path, entered_flags, _] = s:entered_flags(args, s:silicon)
+  let remaining_flags = s:remaining_flags(all_flags, entered_flags)
+  let matches = matchlist(a:arglead, '\v^--([[:lower:]\-]+)(\=(.+)?)?$')
+  if !empty(matches)
+    let [key, eq, val] = matches[1:3]
+    if !empty(eq)
+      if has_key(s:silicon, key)
+        " Complete value
+        return map(s:silicon[key][s:compfun](key, val), "'--'.key.'='.v:val")
+      el
+        return []
+      en
+    el
+      " Complete key
+      let completions = values(map(filter(remaining_flags,
+            \ "v:key =~? '^'.key"), "'--'.v:key"))
+      return len(completions) == 1 ? [completions[0].'='] : sort(completions)
+    en
+  elseif a:arglead == entered_path
+    " Complete path
+    return s:silicon['output'][s:compfun]('output', entered_path)
+  el
+    " Complete remaining flags
+    let completions = values(map(remaining_flags, "'--'.v:key"))
+    return len(completions) == 1 ? [completions[0].'='] : sort(completions)
+  en
+endfun

--- a/doc/silicon.txt
+++ b/doc/silicon.txt
@@ -38,7 +38,6 @@ to install silicon, which is most easily done using cargo:
 COMMANDS                                                *vim-silicon-commands*
 
     1. Silicon ........................................... |:Silicon|
-    2. SiliconHighlight .................................. |:SiliconHighlight|
 
 ------------------------------------------------------------------------------
                                                                     *:Silicon*
@@ -59,6 +58,10 @@ Examples:
     " Generate an image of the current visual line selection
     " and write it to /path/to/output.png
     :'<,'>Silicon /path/to/output.png
+
+    " Generate an image of the current buffer, with the current visual line
+    " selection highlighted.
+    :'<,'>Silicon! /path/to/output.png
 >
 
 ------------------------------------------------------------------------------
@@ -70,8 +73,9 @@ visual line selection highlighted.
 ==============================================================================
 OPTIONS                                                  *vim-silicon-options*
 
-    g:silicon ............................... |g:silicon|
-    g:silicon['default-file-name'] .......... |g:silicon['default-file-name']|
+    g:silicon .......................................... |g:silicon|
+    g:silicon-function ................................. |g:silicon|
+    g:silicon['output'] ................................ |g:silicon['output']|
 
 ------------------------------------------------------------------------------
                                                                    *g:silicon*
@@ -79,20 +83,19 @@ Type: dict ~
 Default: ~
 >
     let g:silicon = {
-          \ 'theme':              'Dracula',
-          \ 'font':                  'Hack',
-          \ 'background':         '#aaaaff',
-          \ 'shadow-color':       '#555555',
-          \ 'line-pad':                   2,
-          \ 'pad-horiz':                 80,
-          \ 'pad-vert':                 100,
-          \ 'shadow-blur-radius':         0,
-          \ 'shadow-offset-x':            0,
-          \ 'shadow-offset-y':            0,
-          \ 'line-number':           v:true,
-          \ 'round-corner':          v:true,
-          \ 'window-controls':       v:true,
-          \ 'default-file-pattern'       '',
+          \   'theme':              'Dracula',
+          \   'font':                  'Hack',
+          \   'background':         '#AAAAFF',
+          \   'shadow-color':       '#555555',
+          \   'line-pad':                   2,
+          \   'pad-horiz':                 80,
+          \   'pad-vert':                 100,
+          \   'shadow-blur-radius':         0,
+          \   'shadow-offset-x':            0,
+          \   'shadow-offset-y':            0,
+          \   'line-number':           v:true,
+          \   'round-corner':          v:true,
+          \   'window-controls':       v:true,
           \ }
 >
 
@@ -101,22 +104,53 @@ To get the list of available themes, you can run this in the terminal:
 >
     silicon --list-themes
 >
-
-For more details about options, please see https://github.com/Aloxaf/silicon.
+>
+For more details about each option, see https://github.com/Aloxaf/silicon.
 
 ------------------------------------------------------------------------------
-                                           *g:silicon['default-file-pattern']*
+                                                          *g:silicon-function*
+
+Instead of assigning values to flags in `g:silicon`, you can assign functions
+which expand into values right before generating the images.
+
+For example, to save images into different directories depending on whether
+you are at work or not, you can use the following.
+
+>
+    let s:workhours = {
+          \ 'Monday':    [8, 16],
+          \ 'Tuesday':   [9, 17],
+          \ 'Wednesday': [9, 17],
+          \ 'Thursday':  [9, 17],
+          \ 'Friday':    [9, 15],
+          \ }
+
+    function! s:working()
+        let day = strftime('%u')
+        if has_key(s:workhours, day)
+          let hour = strftime('%H')
+          let [start_hour, stop_hour] = s:workhours[day]
+          if start_hour <= hour && hour <= stop_hour
+            return "~/Work-Snippets/"
+          endif
+        endif
+        return "~/Personal-Snippets/"
+    endfunction
+
+    let g:silicon['output'] = function('s:working')
+>
+
+------------------------------------------------------------------------------
+                                                         *g:silicon['output']*
 
 If set to a non-empty string, it'll be used as the default filename when
-|:Silicon| is called with no arguments. Note that this means you could no
-longer copy to clipboard, unless you manually reset it to an empty string.
+|:Silicon| is called with no arguments.
 
 It's possible to embed a timestamp into the filename by using the
 `{time:<strftime() specifier>}` format. As an example:
 
 >
-    let g:silicon['default-file-pattern'] =
-            \ '~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png'
+    let g:silicon['output'] = '~/images/silicon-{time:%Y-%m-%d-%H%M%S}.png'
 >
 
 This might result in the file: `~/images/silicon-2019-08-10-164233.png`.
@@ -129,7 +163,7 @@ See |strftime()| and |expand()| for more information.
 ==============================================================================
 NOTES                                                      *vim-silicon-notes*
 
-Currently, `silicon` only supports copying to clipboard on Linux.
+Currently, `silicon` only supports copying to clipboard on Linux and macOS.
 
 ==============================================================================
 " vim:tw=78:ts=4:sts=4:sw=4:ft=help:norl:

--- a/plugin/silicon.vim
+++ b/plugin/silicon.vim
@@ -1,18 +1,20 @@
 " vim: et sw=2 sts=2
 
 " Plugin:      https://github.com/segeljakt/vim-silicon
-" Description: Create beautiful images of your source code.
+" Description: Create beautiful images of source code.
 " Maintainer:  Klas Segeljakt <http://github.com/segeljakt>
 
 com!
+  \ -bang
   \ -range=%
-  \ -nargs=?
-  \ -complete=dir
-  \ Silicon call silicon#generate(<line1>, <line2>, <f-args>)
+  \ -nargs=*
+  \ -complete=customlist,silicon#complete
+  \ Silicon
+  \ call silicon#generate(<bang>0, <line1>, <line2>, <f-args>)
 
 com!
   \ -range
-  \ -nargs=?
-  \ -complete=dir
-  \ SiliconHighlight call silicon#generate_highlighted(<line1>, <line2>, <f-args>)
+  \ -nargs=*
+  \ SiliconHighlight
+  \ echoerr "`SiliconHighlight` is deprecated, use `Silicon!` instead"
 

--- a/tests/minimal-vimrc
+++ b/tests/minimal-vimrc
@@ -1,0 +1,3 @@
+call plug#begin('~/.vim/plugged')
+Plug 'segeljakt/vim-silicon'
+call plug#end()

--- a/tests/suite.vim
+++ b/tests/suite.vim
@@ -1,0 +1,27 @@
+" <This line will be generated>
+
+" Setup
+
+source ./minimal-vimrc
+
+" Tests (Might need to execute manually)
+
+Silicon ./test-img-1.png
+      \ --background=#FFFFFF
+      \ --font=Arial
+      \ --language=java
+      \ --line-number=true
+      \ --line-pad=1
+      \ --pad-horiz=500
+      \ --pad-vert=500
+      \ --round-corner=true
+      \ --shadow-blur-radius=0
+      \ --shadow-color=#555555
+      \ --shadow-offset-x=0
+      \ --shadow-offset-y=0
+      \ --theme=1337
+
+Silicon ./test-img-2.png
+
+Silicon! ./test-img-3.png
+


### PR DESCRIPTION
Version 2 features:
* Completions for paths, flag names, and flag values.
* Clipboard support (only macOS and Linux at the moment).
* `SiliconHighlight`, which generates an image with highlighted lines, has been renamed to `Silicon!` and can be used as:
```vim
'<,'>Silicon! foo.png
```
* `default-output-path`, which sets a default output path, has been renamed to 'output':
```vim
let g:silicon['output'] = '~/Desktop/'
```
**NOTE:** `g:silicon['default-output-path']` still works but is deprecated, so if your configuration already contains it you can keep it as it is.
* Ability to override language and fonts (try out when using completions).
**NOTE:** All fonts might not work, I am not sure why but I will investigate.
* Instead of assigning values to flags in `g:silicon`, you can assign functions which expand into values right before generating the images. For example, to save images into different directories depending on whether you are at work or not:
```vim
let s:workdays = {
      \ 'Monday':    [8, 16],
      \ 'Tuesday':   [9, 17],
      \ 'Wednesday': [9, 17],
      \ 'Thursday':  [9, 17],
      \ 'Friday':    [9, 15],
      \ }

function! s:working()
    let day = strftime('%u')
    if has_key(s:workdays, day)
      let hour = strftime('%H')
      let [start_hour, stop_hour] = s:workdays[day]
      if start_hour <= hour && hour <= stop_hour
        return "~/Work-Snippets/"
      endif
    endif
    return "~/Personal-Snippets/"
endfunction

let g:silicon['output'] = function('s:working')
```
* Debug mode, prints and copies debugging to clipboard when active. This might be useful for posting GitHub issues.
```vim
let g:silicon#debug = v:true
```