### PR TITLE
Add --to-clipboard support for Windows

### DIFF
--- a/autoload/silicon.vim
+++ b/autoload/silicon.vim
@@ -229,7 +229,7 @@ let s:os = has('win64') || has('win32') || has('win16') ? 'Windows' :
 
 " Info: Infer the --to-clipboard flag
 fun! s:infer_to_clipboard()
-  return !empty(executable('xclip')) || s:os ==# 'Darwin'
+  return !empty(executable('xclip')) || s:os ==# 'Darwin' || s:os ==# 'Windows'
 endfun
 
 " ----------------------------- Command builder ------------------------------


### PR DESCRIPTION
With https://github.com/Aloxaf/silicon/pull/108 it should now be possible to use `--to-clipboard` for Windows. This can be merged as soon as the changes are published on www.crates.io/silicon.